### PR TITLE
Don't accept a group until it has zero desired canaries

### DIFF
--- a/lib/nomade/deployer.rb
+++ b/lib/nomade/deployer.rb
@@ -416,7 +416,7 @@ module Nomade
 
           if manual_work_required
             @logger.info "#{json["ID"]} #{task_name}: #{healthy_allocations}/#{desired_canaries}/#{desired_total} (Healthy/WantedCanaries/Total)"
-            announced_completed << task_name if healthy_allocations == desired_canaries
+            announced_completed << task_name if healthy_allocations == desired_canaries && desired_canaries > 0
           else
             @logger.info "#{json["ID"]} #{task_name}: #{healthy_allocations}/#{desired_total} (Healthy/Total)"
             announced_completed << task_name if healthy_allocations == desired_total


### PR DESCRIPTION
Apparently it happens, that nomad returns 0 desired canaries for some time in start of deployment.