### PR TITLE
Handle jobs without allocations

### DIFF
--- a/lib/nomade/deployer.rb
+++ b/lib/nomade/deployer.rb
@@ -222,7 +222,7 @@ module Nomade
 
         @logger.info "Waiting until allocations are no longer pending"
         allocations = []
-        until !allocations.empty? && allocations.all?{|a| a["ClientStatus"] != "pending"}
+        until allocations.all?{|a| a["ClientStatus"] != "pending"}
           @logger.info "."
           sleep(2)
           allocations = @http.allocations_from_evaluation_request(@evaluation_id)


### PR DESCRIPTION
Isn't it the case that after the evaluation is ready, the allocations
will already be there?